### PR TITLE
Fix cursor goes to the left margin

### DIFF
--- a/terminal/src/main/java/org/jline/utils/Display.java
+++ b/terminal/src/main/java/org/jline/utils/Display.java
@@ -466,9 +466,7 @@ public class Display {
                 c0 = 0;
             }
         }
-        if (c0 != 0 && c1 == 0) {
-            terminal.puts(Capability.carriage_return);
-        } else if (c0 < c1) {
+        if (c0 < c1) {
             perform(Capability.cursor_right, Capability.parm_right_cursor, c1 - c0);
         } else if (c0 > c1) {
             perform(Capability.cursor_left, Capability.parm_left_cursor, c0 - c1);


### PR DESCRIPTION
Problem found: the cursor starts in a column different from zero with no prompt. Once written something, if the cursor gets back to the first position (deleting or moving left), it goes back to the left margin instead the starting column.