### PR TITLE
Fix cursor goes to left margin

### DIFF
--- a/terminal/src/main/java/org/jline/utils/Display.java
+++ b/terminal/src/main/java/org/jline/utils/Display.java
@@ -466,9 +466,7 @@ public class Display {
                 c0 = 0;
             }
         }
-        if (c0 != 0 && c1 == 0) {
-            terminal.puts(Capability.carriage_return);
-        } else if (c0 < c1) {
+        if (c0 < c1) {
             perform(Capability.cursor_right, Capability.parm_right_cursor, c1 - c0);
         } else if (c0 > c1) {
             perform(Capability.cursor_left, Capability.parm_left_cursor, c0 - c1);


### PR DESCRIPTION
Use case. Reading a line when the cursor is not at the left margin without prompt (System.out.print something): the user has written something and then deletes the input or moves the cursor back to the first position, the cursor instead of going to the starting column it goes back all the way to the left margin.